### PR TITLE
Revert docs move and add GH Pages workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,38 @@
+name: Deploy GitHub Pages site
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+      - run: bundle install
+      - run: bundle exec jekyll build --source site --destination _site
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: _site
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v2
+        id: deployment

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -1,5 +1,7 @@
 title: "TENSOR Framework"
 markdown: kramdown
+url: "https://tensor-standards-consortium.github.io"
+baseurl: "/TENSOR-Website"
 sass:
   style: compressed
 


### PR DESCRIPTION
## Summary
- revert previous move of Jekyll source into `docs`
- keep site in `site/` and configure `url` and `baseurl`
- add GitHub Actions workflow to build from `site` and deploy to Pages

## Testing
- `bundle exec jekyll build --source site --destination site/_site`
